### PR TITLE
Adds support for OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Open up `llm_serve.py`, and you can change the `MODEL_NAME` to point to another 
 ## TODO ##
 - [x] Visually distinguish game response from player commands
 - [x] Hook up debug log viewing from the web
-- [ ] Add support for OpenAI models
+- [x] Add support for OpenAI models
 
 ## Known Issues ##
 * The rewrite sometimes make up unrelated content or completely lose the structure of original game text, especially when using less capable models.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,34 @@ Enter LLMs. What if we can leverage them to repair unrecognized commands, improv
 
 You can run the example locally with an Anthropic API key. Alternatively, you can deploy the project using [Modal](https://modal.com/) (they offer $30 worth of hosting credit for free each month) to play it from the web, using a LLM of your choice.
 
-## Running Locally
+## Setting up your Anthropic/OpenAI API Key
 
-To run the game `9:05` locally in Anthropic:
+To use Anthropic or OpenAI models for the project, you need to specify your keys. To do so, create a `.env` file in the project directory, and then enter your API keys:
 
 ```
-export ANTHROPIC_API_KEY=sk-...
-python local.py games/905.z5
+ANTHROPIC_API_KEY=sk-...
+OPENAI_API_KEY=sk-proj...
+```
+
+### Changing the Anthropic/OpenAI Model ###
+
+By default, the project uses Claude 3.5 Sonnet on Anthropic, and gpt-4o-mini on OpenAI.
+
+You can change the model to use by modifying `ANTHROPIC_MODEL` and `OPENAI_MODEL` in `utils.py`.
+
+
+## Running Locally
+
+To run the game `9:05` locally with Anthropic (defaults to Claude 3.5 Sonnet):
+
+```
+python local.py games/905.z5 --llm anthropic
+```
+
+If you want to use an OpenAI model (defaults to gpt-4o-mini):
+
+```
+python local.py games/905.z5 --llm openai
 ```
 
 ## Deploy and Play from Browser
@@ -39,15 +60,8 @@ cd ..
 modal deploy web
 ```
 
-If you want to use Anthropic model when running in the web, enter your API key in a `.env` file like so:
 
-```
-ANTHROPIC_API_KEY=sk-...
-```
-
-Then deploy as usual.
-
-### Changing the Model ###
+### Changing the Hosted Model ###
 
 Open up `llm_serve.py`, and you can change the `MODEL_NAME` to point to another model available on HuggingFace that is supported by vLLM. Be sure to `modal deploy web` again after making the change, and Modal will rebuild the image and deploy accordingly.
 

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -131,10 +131,10 @@ and feeling rather foolish)."
 parser_preamble = '''
 This response is due to a limitation of the game engine and its text parser.  
 
-The game understands the following verbs and prepositions, where all words on the same line are synonyms.
+The game understands the following verbs and prepositions, separated by commas:
 {{{verbs}}}
 
-The game understands the following noun phrases, where all noun phrases on the same line are synonyms.
+The game understands the following noun phrases, separated by commas:
 {{{nouns}}}
 
 '''
@@ -153,10 +153,10 @@ The following commands (one per line) are possibly valid actions that the game m
 '''
 
 parser_suffix = '''
-Rewrite the player's command into one that the game accepts and aligns as closely as possible with the player's intent.
+Rewrite the player's command into a single line of text that the game accepts and aligns with the player's intent.
 
 First, explain why each word of your rewritten command is a good choice.
 
-Then enclose your suggested new command in triple plusses, as follows:
+Then enclose your suggested new command in triple plusses, in a single line of text, as follows:
 +++SUGGESTION+++
 '''

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -22,7 +22,7 @@ const App = () => {
   const [game, setGame] = useState(GAMES[0].id)
   const [tone, setTone] = useState(TONES[0].id)
   const [llm, setLlm] = useState(LLMS[0].id)
-  const [isStartGameOpen, setIsStartGameOpen] = useState(false)
+  const [isStartGameOpen, setIsStartGameOpen] = useState(true)
   const [isStartingGame, setIsStartingGame] = useState(false)
   const [isProcessingCommand, setIsProcessingCommand] = useState(false)
   const [visibleSections, setVisibleSections] = useState(['game', 'original'])
@@ -166,16 +166,12 @@ const App = () => {
     <>
       {!gameStateId && (
         <div className='min-w-full min-h-screen bg-gray-100 screen flex flex-col gap-6 justify-center items-center'>
-          <Heading>LLM-IF-Wrapper</Heading>
-          <Button onClick={() => setIsStartGameOpen(true)} size='4'>
-            Start Game
-          </Button>
-
           <Dialog.Root open={isStartGameOpen}>
             <Dialog.Content maxWidth='450px'>
               <Dialog.Title>Start Game</Dialog.Title>
               <Dialog.Description size='2' mb='4'>
-                Select a game and a rewrite tone for the story.
+                Select a classic interactive fiction game and an optional
+                rewrite tone below.
               </Dialog.Description>
 
               <Flex direction='column' gap='3'>
@@ -251,19 +247,22 @@ const App = () => {
                       </Text>
                     </Box>
                   )}
+                  {llm === 'openai' && (
+                    <Box>
+                      <Text size='1'>
+                        Make sure you provided a valid{' '}
+                        <Code>OPENAI_API_KEY</Code>
+                        in <Code>.env</Code> file for your deployed Modal
+                        endpoint.
+                      </Text>
+                    </Box>
+                  )}
                 </label>
               </Flex>
 
               <Flex gap='3' mt='4' justify='end'>
-                <Button
-                  onClick={() => setIsStartGameOpen(false)}
-                  variant='soft'
-                  color='gray'
-                >
-                  Cancel
-                </Button>
                 <Button loading={isStartingGame} onClick={startGame}>
-                  Start
+                  Start Game
                 </Button>
               </Flex>
             </Dialog.Content>

--- a/frontend/src/app/settings.tsx
+++ b/frontend/src/app/settings.tsx
@@ -50,6 +50,7 @@ export const TONES = [
 
 export const LLMS = [
   { id: 'anthropic', label: 'Claude 3.5 Sonnet' },
+  { id: 'openai', label: 'GPT-4o-mini' },
   { id: 'hosted', label: 'Hosted' }
 ]
 

--- a/game.py
+++ b/game.py
@@ -49,9 +49,9 @@ def try_to_fix_parser_error(command, response):
 
     # get all the verbs for the game, and all the nouns accessible in the current room
     verbs = [w for w in state.env.get_dictionary() if w.is_verb]
-    verbs = "\n".join([f'"{verb}"' for verb in verbs])
+    verbs = ", ".join([f'"{v.word}"' for v in verbs])
     nouns = [w for w in state.env.get_dictionary() if w.is_noun]
-    nouns = "\n".join([f'"{noun}"' for noun in nouns])
+    nouns = ", ".join([f'"{n.word}"' for n in nouns])
 
     # try several times to get the LLM to make a command that doesn't result in an parser error
     preamble = config["errors"]["parser_preamble"].replace("{{{verbs}}}", verbs)
@@ -84,6 +84,7 @@ def try_to_fix_parser_error(command, response):
             )
             concat_current_llm_prompt(failed_tries_prompt)
         concat_current_llm_prompt(config["errors"]["parser_suffix"])
+
         llm_response = get_llm_response()
 
         # Attempt to parse out the newly suggested command

--- a/local.py
+++ b/local.py
@@ -1,5 +1,7 @@
 import argparse
 import curses
+from dotenv import load_dotenv
+
 from state import init_game_state, set_current_state
 from splitscreen import SplitScreen
 import engine
@@ -56,9 +58,22 @@ def main(stdscr, game_path, llm="anthropic", tone="pratchett"):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("game_path")
-    parser.add_argument("-l", "--llm", help="LLM provider", default="anthropic")
-    parser.add_argument("-t", "--tone", help="Tone of rewrite", default="pratchett")
+    parser.add_argument(
+        "-l",
+        "--llm",
+        help="LLM provider",
+        choices=["anthropic", "openai", "hosted"],
+        default="anthropic",
+    )
+    parser.add_argument(
+        "-t",
+        "--tone",
+        help="Tone of rewrite",
+        choices=["none", "original", "pratchett", "gumshoe", "legal", "spaceopera"],
+        default="none",
+    )
 
     args = parser.parse_args()
+    load_dotenv()
 
     curses.wrapper(main, args.game_path, args.llm, args.tone)

--- a/web.py
+++ b/web.py
@@ -12,6 +12,10 @@ static_path = os.path.join(os.getcwd(), "frontend", "out")
 game_path = os.path.join(os.getcwd(), "games")
 config_path = os.path.join(os.getcwd(), "configs")
 
+web_api_image = modal.Image.debian_slim(python_version="3.11").pip_install(
+    "anthropic", "openai", "jericho"
+)
+
 
 @app.function(
     mounts=[
@@ -24,6 +28,7 @@ config_path = os.path.join(os.getcwd(), "configs")
     secrets=[modal.Secret.from_dotenv()],
     container_idle_timeout=300,
     timeout=600,
+    image=web_api_image,
 )
 @modal.asgi_app()
 def web():


### PR DESCRIPTION
* adds support for `openai` in LLM options, default to `gpt-4o-mini`
* updates `local.py` command line arguments to allow for no rewrite
* `loca.py` also uses dotenv for getting API tokens to activate LLM APIs
* web: shows start game dialog on open
* logs prompts sent in LLM API calls
* explicitly defines image used for web API